### PR TITLE
Adds an optional dark mode to the site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,8 @@ theme = "hugo-theme-basic"
 enableEmoji = true
 description = "Stefan VanBuren's personal site."
 pygmentsCodeFences = true
-pygmentsStyle = "algol_nu"
+pygmentsStyle = "solarized-dark"
+pygmentsUseClasses = false
 
 [[params.menu]]
   name = "blog"

--- a/themes/hugo-theme-basic/layouts/_default/list.html
+++ b/themes/hugo-theme-basic/layouts/_default/list.html
@@ -6,7 +6,7 @@
   <span class="b">/ </span>
   <a
     href="{{ .Site.BaseURL  }}"
-    class="b bw1 bb pb1 no-underline black"
+    class="b bw1 bb pb1 no-underline"
     >{{ .Site.Title  }}</a
   >
   <section id="main" class="mt5">
@@ -16,7 +16,7 @@
         {{ range .Data.Pages.ByDate.Reverse }}
         <li class="list pl0 lh-copy">
           <a
-            class="f3 b dib black no-underline"
+            class="f3 b dib no-underline"
             href="{{ .Permalink}}"
             >{{ .Title }}</a
           >

--- a/themes/hugo-theme-basic/layouts/_default/single.html
+++ b/themes/hugo-theme-basic/layouts/_default/single.html
@@ -9,7 +9,7 @@
   <span class="b">/ </span>
   <a
     href="{{ .Site.BaseURL  }}"
-    class="b bb bw1 pb1 no-underline black"
+    class="b bb bw1 pb1 no-underline"
     >{{ .Site.Title }}</a
   >
 

--- a/themes/hugo-theme-basic/layouts/_default/terms.html
+++ b/themes/hugo-theme-basic/layouts/_default/terms.html
@@ -6,12 +6,12 @@
   <span class="b">/ </span>
   <a
     href="{{ .Site.BaseURL  }}"
-    class="b bw1 bb pb1 no-underline black"
+    class="b bw1 bb pb1 no-underline"
     >{{ .Site.Title }}</a
   >
   <span class="b"> / </span>
   <!-- prettier-ignore -->
-  <span class="b pb1 no-underline black">{{ lower .Title }}</span>
+  <span class="b pb1 no-underline">{{ lower .Title }}</span>
 
   <section id="main" class="mt5">
     <div>
@@ -21,7 +21,7 @@
         {{ if ne .Title "" }}
         <li class="list pl0 lh-copy hide-child">
           <a
-            class="f4 b dib black no-underline"
+            class="f4 b dib no-underline"
             href="{{ .Permalink}}"
             >{{ .Title }}</a
           >

--- a/themes/hugo-theme-basic/layouts/index.html
+++ b/themes/hugo-theme-basic/layouts/index.html
@@ -36,7 +36,7 @@
           <!-- prettier-ignore -->
           {{ range .Site.Params.menu }}
           <li class="b mv3">
-            <a class="f3 b pa1 black" href="{{ .url }}">{{ .name }}</a>
+            <a class="f3 b pa1" href="{{ .url }}">{{ .name }}</a>
           </li>
           <!-- prettier-ignore -->
           {{ end }}

--- a/themes/hugo-theme-basic/layouts/partials/footer.html
+++ b/themes/hugo-theme-basic/layouts/partials/footer.html
@@ -4,4 +4,5 @@
       {{ .Site.Copyright  | safeHTML }}
     </p>
   </div>
+  <dark-mode-toggle appearance="toggle" permanent></dark-mode-toggle>
 </footer>

--- a/themes/hugo-theme-basic/layouts/partials/head_includes.html
+++ b/themes/hugo-theme-basic/layouts/partials/head_includes.html
@@ -9,5 +9,4 @@
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/light.css" media="(prefers-color-scheme: no-preference), (prefers-color-scheme: light)">
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/dark.css" media="(prefers-color-scheme: dark)">
 
-
 <script type="module" src="https://cdn.pika.dev/dark-mode-toggle"></script>

--- a/themes/hugo-theme-basic/layouts/partials/head_includes.html
+++ b/themes/hugo-theme-basic/layouts/partials/head_includes.html
@@ -6,3 +6,8 @@
 <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans|IBM+Plex+Mono:400,700&display=swap" rel="stylesheet">
 
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css" />
+<link rel="stylesheet" href="{{ .Site.BaseURL }}css/light.css" media="(prefers-color-scheme: no-preference), (prefers-color-scheme: light)">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}css/dark.css" media="(prefers-color-scheme: dark)">
+
+
+<script type="module" src="https://cdn.pika.dev/dark-mode-toggle"></script>

--- a/themes/hugo-theme-basic/layouts/post/single.html
+++ b/themes/hugo-theme-basic/layouts/post/single.html
@@ -7,9 +7,9 @@
 >
 
   <span class="b">/ </span>
-  <a href="{{ .Site.BaseURL  }}" class="b bb bw1 pb1 no-underline black">{{ .Site.Title }}</a>
+  <a href="{{ .Site.BaseURL  }}" class="b bb bw1 pb1 no-underline">{{ .Site.Title }}</a>
   <span class="b"> / </span>
-  <a href="/post" class="b bb bw1 pb1 no-underline black">blog</a>
+  <a href="/post" class="b bb bw1 pb1 no-underline">blog</a>
 
   <section id="main" class="mt5">
     <h1 itemprop="name" id="title">{{ .Title }}</h1>
@@ -30,7 +30,7 @@
         <section class="mt4">
           {{ $readMore := ":wave:" }}
           {{ $series := .Params.series | urlize}}
-          <h3>{{ $readMore | emojify }} Related posts in the <a href="/series/{{ $series }}" class="b bb bw1 pb1 no-underline black">{{ .Params.Series }}</a> series...</h3>
+          <h3>{{ $readMore | emojify }} Related posts in the <a href="/series/{{ $series }}" class="b bb bw1 pb1 no-underline">{{ .Params.Series }}</a> series...</h3>
 
           {{ $posts := index .Site.Taxonomies.series $series }}
 
@@ -39,7 +39,7 @@
               {{ range where $posts "Title" "!=" .Title }}
                 <li class="list pl0 lh-copy">
                   <a
-                    class="f4 b dib black no-underline"
+                    class="f4 b dib no-underline"
                     href="{{ .Permalink}}"
                     >{{ .Title }}</a
                   >

--- a/themes/hugo-theme-basic/layouts/project/single.html
+++ b/themes/hugo-theme-basic/layouts/project/single.html
@@ -9,7 +9,7 @@
   <span class="b">/ </span>
   <a
     href="{{ .Site.BaseURL  }}"
-    class="b bb bw1 pb1 no-underline black"
+    class="b bb bw1 pb1 no-underline"
     >{{ .Site.Title }}</a
   >
 

--- a/themes/hugo-theme-basic/layouts/taxonomy/category.html
+++ b/themes/hugo-theme-basic/layouts/taxonomy/category.html
@@ -6,14 +6,14 @@
   <span class="b">/ </span>
   <a
     href="{{ .Site.BaseURL  }}"
-    class="b bw1 bb pb1 no-underline black"
+    class="b bw1 bb pb1 no-underline"
     >{{ .Site.Title  }}</a
   >
   <span class="b"> / </span>
-  <a href="/categories" class="b bw1 bb pb1 no-underline black">categories</a>
+  <a href="/categories" class="b bw1 bb pb1 no-underline">categories</a>
   <span class="b"> / </span>
   <!-- prettier-ignore -->
-  <span class="b pb1 no-underline black">{{ .Title | lower }}</span>
+  <span class="b pb1 no-underline">{{ .Title | lower }}</span>
 
   <section id="main" class="mt5">
     <div>
@@ -22,7 +22,7 @@
         {{ range .Data.Pages.ByDate.Reverse }}
         <li class="list pl0 lh-copy">
           <a
-            class="f3 b dib black no-underline"
+            class="f3 b dib no-underline"
             href="{{ .Permalink}}"
             >{{ .Title }}</a
           >

--- a/themes/hugo-theme-basic/layouts/taxonomy/series.html
+++ b/themes/hugo-theme-basic/layouts/taxonomy/series.html
@@ -6,14 +6,14 @@
   <span class="b">/ </span>
   <a
     href="{{ .Site.BaseURL  }}"
-    class="b bw1 bb pb1 no-underline black"
+    class="b bw1 bb pb1 no-underline"
     >{{ .Site.Title  }}</a
   >
   <span class="b"> / </span>
-  <a href="/series" class="b bw1 bb pb1 no-underline black">series</a>
+  <a href="/series" class="b bw1 bb pb1 no-underline">series</a>
   <span class="b"> / </span>
   <!-- prettier-ignore -->
-  <span class="b pb1 no-underline black">{{ .Title | lower }}</span>
+  <span class="b pb1 no-underline">{{ .Title | lower }}</span>
 
   <section id="main" class="mt5">
     <div>
@@ -22,7 +22,7 @@
         {{ range .Data.Pages.ByDate.Reverse }}
         <li class="list pl0 lh-copy">
           <a
-            class="f3 b dib black no-underline"
+            class="f3 b dib no-underline"
             href="{{ .Permalink}}"
             >{{ .Title }}</a
           >

--- a/themes/hugo-theme-basic/layouts/taxonomy/tag.html
+++ b/themes/hugo-theme-basic/layouts/taxonomy/tag.html
@@ -6,14 +6,14 @@
   <span class="b">/ </span>
   <a
     href="{{ .Site.BaseURL  }}"
-    class="b bw1 bb pb1 no-underline black"
+    class="b bw1 bb pb1 no-underline"
     >{{ .Site.Title  }}</a
   >
   <span class="b"> / </span>
-  <a href="/tags" class="b bw1 bb pb1 no-underline black">tags</a>
+  <a href="/tags" class="b bw1 bb pb1 no-underline">tags</a>
   <span class="b"> / </span>
   <!-- prettier-ignore -->
-  <span class="b pb1 no-underline black">{{ .Title | lower }}</span>
+  <span class="b pb1 no-underline">{{ .Title | lower }}</span>
 
   <section id="main" class="mt5">
     <div>
@@ -22,7 +22,7 @@
         {{ range .Data.Pages.ByDate.Reverse }}
         <li class="list pl0 lh-copy">
           <a
-            class="f3 b dib black no-underline"
+            class="f3 b dib no-underline"
             href="{{ .Permalink}}"
             >{{ .Title }}</a
           >

--- a/themes/hugo-theme-basic/static/css/dark.css
+++ b/themes/hugo-theme-basic/static/css/dark.css
@@ -1,0 +1,24 @@
+:root {
+  --color: rgb(250, 250, 250);
+  --background-color: rgb(5, 5, 5);
+  --link-color: rgb(0, 188, 212);
+  --main-headline-color: rgb(233, 30, 99);
+  --accent-background-color: rgb(0, 188, 212);
+  --accent-color: rgb(5, 5, 5);
+}
+
+a {
+  position: relative;
+  color: #FF4900;
+  text-decoration: none;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-position: 0% 100%;
+  background-repeat: no-repeat;
+  background-size: 0% 2px;
+  transition: background-size .3s;
+}
+
+a:hover {
+  color: #FF4900;
+  background-size: 100% 2px;
+}

--- a/themes/hugo-theme-basic/static/css/light.css
+++ b/themes/hugo-theme-basic/static/css/light.css
@@ -1,0 +1,24 @@
+:root {
+  --color: rgb(5, 5, 5);
+  --background-color: rgb(250, 250, 250);
+  --link-color: rgb(0, 0, 238);
+  --main-headline-color: rgb(0, 0, 192);
+  --accent-background-color: rgb(0, 0, 238);
+  --accent-color: rgb(250, 250, 250);
+}
+
+a {
+  position: relative;
+  color: #3F00FF;
+  text-decoration: none;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-position: 0% 100%;
+  background-repeat: no-repeat;
+  background-size: 0% 2px;
+  transition: background-size .3s;
+}
+
+a:hover {
+  color: #3F00FF;
+  background-size: 100% 2px;
+}

--- a/themes/hugo-theme-basic/static/css/style.css
+++ b/themes/hugo-theme-basic/static/css/style.css
@@ -1,7 +1,21 @@
+:root {
+  color-scheme: light dark;
+}
+
 body {
+  color: var(--color);
+  background-color: var(--background-color);
   -webkit-font-smoothings: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+
+  /* Adds a transition, which is a bit jarring when the OS is set to light mode but the site remembers dark mode, and vice versa */
+  /* --duration: 0.5s; */
+  /* --timing: ease; */
+
+  /* transition: */
+  /*   color var(--duration) var(--timing), */
+  /*   background-color var(--duration) var(--timing); */
 }
 
 article, h1 {
@@ -11,8 +25,6 @@ article, h1 {
 code {
   padding: 2px 4px;
   font-size: 80%;
-  background-color: #fff;
-  /* border-radius: 4px; */
 }
 
 pre {
@@ -24,8 +36,7 @@ pre {
   word-wrap: break-word;
   white-space: pre;
   overflow-x: auto;
-  border: 1px solid #ccc;
-  /* border-radius: 4px; */
+  border: 1px solid var(--background-color);
 }
 
 pre,
@@ -33,37 +44,4 @@ code {
   font-family: 'IBM Plex Mono', monocode, monospace;
   -webkit-font-smoothings: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-/* Roughly borrowed from https://tobiasahlin.com/blog/css-trick-animating-link-underlines/ */
-
-a {
-  position: relative;
-  color: #3F00FF;
-  text-decoration: none;
-}
-
-a:hover {
-  color: #3F00FF;
-}
-
-a:before {
-  content: "";
-  position: absolute;
-  width: 100%;
-  height: 2px;
-  bottom: 0;
-  left: 0;
-  background-color: #000;
-  visibility: hidden;
-  -webkit-transform: scaleX(0);
-  transform: scaleX(0);
-  -webkit-transition: all 0.3s ease-in-out 0s;
-  transition: all 0.3s ease-in-out 0s;
-}
-
-a:hover:before {
-  visibility: visible;
-  -webkit-transform: scaleX(1);
-  transform: scaleX(1);
 }

--- a/themes/hugo-theme-basic/static/css/style.css
+++ b/themes/hugo-theme-basic/static/css/style.css
@@ -22,6 +22,11 @@ article, h1 {
   font-family: 'IBM Plex Sans', system-ui;
 }
 
+/* TODO: this should be specific to the lists on pages rather than lists within articles */
+li {
+  font-family: 'IBM Plex Mono', monocode, monospace;
+}
+
 code {
   padding: 2px 4px;
   font-size: 80%;


### PR DESCRIPTION
Dropped a bunch of `black` tachyons classes to make this work; also
switch to solarized-dark since I can't seem to control the background
color of the `pre` blocks due to the way the highlighter works.

This also changes the way the underlines on the links get created
because the previous way was not working across lines.

Closes #9.